### PR TITLE
Support single connection for clients

### DIFF
--- a/src/Monik.Client.Azure/Monik.Client.Azure.csproj
+++ b/src/Monik.Client.Azure/Monik.Client.Azure.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Monik.Client.Base" Version="1.0.0" />
+    <PackageReference Include="Monik.Client.Base" Version="1.0.1" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Monik.Client.Azure/Monik.Client.Azure.csproj
+++ b/src/Monik.Client.Azure/Monik.Client.Azure.csproj
@@ -11,6 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Monik.Client.Base" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Monik.Client.Base/IMonikSender.cs
+++ b/src/Monik.Client.Base/IMonikSender.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Monik.Common;
 
 namespace Monik.Client
 {
-    public interface IMonikSender
+    public interface IMonikSender : IDisposable
     {
         Task SendMessages(IEnumerable<Event> events);
     }

--- a/src/Monik.Client.Base/MonikClient.cs
+++ b/src/Monik.Client.Base/MonikClient.cs
@@ -35,6 +35,8 @@ namespace Monik.Client
             _keepAliveTask?.Wait();
 
             base.OnStop();
+
+            _sender?.Dispose();
         }
 
         protected override Task OnSend(IEnumerable<Event> events)

--- a/src/Monik.Client.RabbitMQ/Monik.Client.RabbitMQ.csproj
+++ b/src/Monik.Client.RabbitMQ/Monik.Client.RabbitMQ.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Totopolis</Authors>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Monik.Client.Base" Version="1.0.0" />
+    <PackageReference Include="Monik.Client.Base" Version="1.0.1" />
     <PackageReference Include="EasyNetQ" Version="3.7.1" />
   </ItemGroup>
 </Project>

--- a/src/Monik.Client.RabbitMQ/RabbitMqSender.cs
+++ b/src/Monik.Client.RabbitMQ/RabbitMqSender.cs
@@ -21,6 +21,9 @@ namespace Monik.Client
 
         public async Task SendMessages(IEnumerable<Event> events)
         {
+            if (!_client.Value.IsConnected)
+                return;
+
             foreach (var ev in events)
             {
                 var body = ev.ToByteArray();

--- a/src/Monik.Client.RabbitMQ/RabbitMqSender.cs
+++ b/src/Monik.Client.RabbitMQ/RabbitMqSender.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using EasyNetQ;
 using EasyNetQ.Topology;
@@ -9,28 +10,33 @@ namespace Monik.Client
 {
     public class RabbitMqSender : IMonikSender
     {
-        private readonly string _connectionString;
         private readonly string _queueName;
+        private readonly Lazy<IAdvancedBus> _client;
 
         public RabbitMqSender(string connectionString, string queueName)
         {
-            _connectionString = connectionString;
             _queueName = queueName;
+            _client = new Lazy<IAdvancedBus>(() => RabbitHutch.CreateBus(connectionString).Advanced);
         }
 
         public async Task SendMessages(IEnumerable<Event> events)
         {
-            using (var client = RabbitHutch.CreateBus(_connectionString).Advanced)
+            foreach (var ev in events)
             {
-                foreach (var ev in events)
-                {
-                    var body = ev.ToByteArray();
+                var body = ev.ToByteArray();
 
-                    await client.PublishAsync(Exchange.GetDefault(),
-                        _queueName, false,
-                        new MessageProperties(),
-                        body);
-                }
+                await _client.Value.PublishAsync(Exchange.GetDefault(),
+                    _queueName, false,
+                    new MessageProperties(),
+                    body);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_client.IsValueCreated)
+            {
+                _client.Value.Dispose();
             }
         }
     }

--- a/src/Monik.Client.SqlQueue/Monik.Client.SqlQueue.csproj
+++ b/src/Monik.Client.SqlQueue/Monik.Client.SqlQueue.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Monik.Client.Base" Version="1.0.0" />
+    <PackageReference Include="Monik.Client.Base" Version="1.0.1" />
     <PackageReference Include="Gerakul.SqlQueue.InMemory" Version="1.5.2" />
   </ItemGroup>
 

--- a/src/Monik.Common/Monik.Common.csproj
+++ b/src/Monik.Common/Monik.Common.csproj
@@ -17,12 +17,12 @@
     <PackageReference Include="EasyNetQ" Version="3.7.1" />
     <PackageReference Include="Gerakul.FastSql.SqlServer" Version="1.0.0" />
     <PackageReference Include="Gerakul.SqlQueue.InMemory" Version="1.5.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
     <PackageReference Include="Nancy" Version="2.0.0" />
     <PackageReference Include="Nancy.Authentication.Stateless" Version="2.0.0" />
     <PackageReference Include="Nancy.Bootstrappers.Autofac" Version="2.0.0-clinteastwood" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
   </ItemGroup>

--- a/tests/Monik.Client.Azure.Test/Monik.Client.Azure.Test.csproj
+++ b/tests/Monik.Client.Azure.Test/Monik.Client.Azure.Test.csproj
@@ -7,7 +7,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />

--- a/tests/Monik.Client.Base.Test/Monik.Client.Base.Test.csproj
+++ b/tests/Monik.Client.Base.Test/Monik.Client.Base.Test.csproj
@@ -7,7 +7,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />

--- a/tests/Monik.Test/Monik.Test.csproj
+++ b/tests/Monik.Test/Monik.Test.csproj
@@ -6,7 +6,7 @@
     <ProjectReference Include="..\..\src\Monik.Common\Monik.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />


### PR DESCRIPTION
Standard practice is to create a single client for queue writing:
* [Rabbit](https://github.com/EasyNetQ/EasyNetQ/wiki/Connecting-to-RabbitMQ)
* [ServiceBus](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-performance-improvements#reusing-factories-and-clients)

**Attention**:
* `OnStop` must be called explicitly, otherwise connection can be still opened and it can prevent application shutdown.